### PR TITLE
Fix Encoding in Replace All Filter

### DIFF
--- a/lib/conductor/filter.rb
+++ b/lib/conductor/filter.rb
@@ -753,6 +753,7 @@ module Conductor
           return content
         end
 
+        content = content.dup.force_encoding("UTF-8") # Enforce UTF-8 encoding
         content.replace_all(@params[0], @params[1])
       when /replace$/
         unless @params.count == 2


### PR DESCRIPTION
For characters like `😊` or `ü`, when running through a replace all filter an error is produced due to defaulting to ASCII encoding. This throws up errors like this to the user:

```
/Users/stephen/.gem/ruby/3.4.0/gems/marked-conductor-1.0.39/lib/conductor/filter.rb:521:in 'String#gsub': invalid byte sequence in US-ASCII (ArgumentError)

gsub(regex.to\_rx, pattern.to\_pattern)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
from /Users/stephen/.gem/ruby/3.4.0/gems/marked-conductor-1.0.39/lib/conductor/filter.rb:521:in 'String#replace\_all'
```

Added a line to the `replaceall` filter to force it to use UTF-8 encoding.