### PR TITLE
fix: use printf instead of echo to preserve backslash escapes in stdin

### DIFF
--- a/lib/conductor/command.rb
+++ b/lib/conductor/command.rb
@@ -67,7 +67,7 @@ module Conductor
       end
 
       if use_stdin
-        `echo #{Shellwords.escape(stdin.utf8)} | #{Env} #{path} #{args}`
+        `printf '%s\n' #{Shellwords.escape(stdin.utf8)} | #{Env} #{path} #{args}`
       else
         `#{Env} #{path} #{args}`
       end

--- a/lib/conductor/script.rb
+++ b/lib/conductor/script.rb
@@ -72,7 +72,7 @@ module Conductor
       end
 
       if use_stdin
-        `echo #{Shellwords.escape(stdin.utf8)} | #{Env} #{@path} #{@args}`
+        `printf '%s\n' #{Shellwords.escape(stdin.utf8)} | #{Env} #{@path} #{@args}`
       else
         `#{Env} #{@path} #{@args}`
       end

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -41,5 +41,15 @@ describe Conductor::Command do
       command.args = "$file".dup
       expect(command.run).to match(/<p>First, there seems to be a misconception that/)
     end
+
+    it "preserves backslash escapes in STDIN" do
+      # A literal backslash-n in the payload (e.g. a D2 label "a\nb") must reach
+      # the downstream processor verbatim. Shell `echo` interprets the escape and
+      # collapses it to a real newline; `printf '%s\n'` emits it as-is.
+      Conductor.stdin = 'label: "a\nb"'
+      command.path = "/bin/cat"
+      command.args = []
+      expect(command.run).to include('a\nb')
+    end
   end
 end

--- a/spec/script_spec.rb
+++ b/spec/script_spec.rb
@@ -43,5 +43,15 @@ describe Conductor::Script do
       script.args = ["${file}"]
       expect(script.run).to match(/First, there seems to be a misconception/)
     end
+
+    it "preserves backslash escapes in STDIN" do
+      # A literal backslash-n in the payload (e.g. a D2 label "a\nb") must reach
+      # the downstream processor verbatim. Shell `echo` interprets the escape and
+      # collapses it to a real newline; `printf '%s\n'` emits it as-is.
+      Conductor.stdin = 'label: "a\nb"'
+      script.path = "/bin/cat"
+      script.args = []
+      expect(script.run).to include('a\nb')
+    end
   end
 end


### PR DESCRIPTION
## Summary

`Command#run` and `Script#run` pipe STDIN to the downstream processor using the shell builtin `echo`, which interprets backslash escapes. Any literal `\n`, `\t`, etc. in the user's content is converted into a real control character before it reaches the processor, splitting quoted strings and corrupting the payload.

This change replaces `echo` with `printf '%s\n'`, which emits its argument verbatim (POSIX-guaranteed, no escape interpretation) while preserving the trailing newline. `Shellwords.escape` is retained.

## Fix

Swap `echo` for `printf '%s\n'` in the `use_stdin` branch of both `Command#run` (`lib/conductor/command.rb`) and `Script#run` (`lib/conductor/script.rb`).

Example config: https://gist.github.com/tkolleh/ef223d337bbae12a74a3547312273e3b - based on https://github.com/tkolleh/markup-diagram-preprocessors
